### PR TITLE
Updates for SDL_iOS v7.1 features

### DIFF
--- a/MobileNav/SDL/ProxyManager.swift
+++ b/MobileNav/SDL/ProxyManager.swift
@@ -114,6 +114,11 @@ class ProxyManager: NSObject {
         let streamingMediaConfig = SDLStreamingMediaConfiguration()
         streamingMediaConfig.carWindowRenderingType = getSDLRenderType(from: streamSettings.renderType)
 
+        // The app supports all possible screen sizes
+        streamingMediaConfig.supportedPortraitStreamingRange = nil
+        streamingMediaConfig.supportedLandscapeStreamingRange = nil
+        streamingMediaConfig.delegate = ProxyManager.sharedManager.self
+
         guard let mapViewController = SDLViewControllers.map else {
             SDLLog.e("Error loading the SDL map view")
             return streamingMediaConfig
@@ -137,8 +142,14 @@ class ProxyManager: NSObject {
     }
 }
 
-// MARK: - SDLManagerDelegate
+// MARK: - SDLStreamingVideoDelegate
+extension ProxyManager: SDLStreamingVideoDelegate {
+    func videoStreamingSizeDidUpdate(_ displaySize: CGSize) {
+        print("video stream size updated to width: \(displaySize.width), height: \(displaySize.height)")
+    }
+}
 
+// MARK: - SDLManagerDelegate
 extension ProxyManager: SDLManagerDelegate {
     func managerDidDisconnect() {
         if proxyState != .stopped {

--- a/MobileNav/SDL/ProxyManager.swift
+++ b/MobileNav/SDL/ProxyManager.swift
@@ -116,9 +116,9 @@ class ProxyManager: NSObject {
 
         streamingMediaConfig.supportedPortraitStreamingRange = SDLVideoStreamingRange(minimumResolution: SDLImageResolution(width: 300, height: 500), maximumResolution: SDLImageResolution(width: UInt16.max, height: UInt16.max))
         streamingMediaConfig.supportedLandscapeStreamingRange = SDLVideoStreamingRange(minimumResolution: SDLImageResolution(width: 500, height: 300), maximumResolution: SDLImageResolution(width: UInt16.max, height: UInt16.max))
-        streamingMediaConfig.delegate = ProxyManager.sharedManager.self
+        streamingMediaConfig.delegate = self
 
-        // The video encoder is configured to use the module's preferred framerate and bitrate. If desired, you can override the module's preferred settings with custom settings.
+        // The video encoder is configured to use the module's preferred framerate and bitrate. If desired, you can provide your custom settings as well. The lowest quality settings between your settings and the module's settings will be used.
         // streamingMediaConfig.customVideoEncoderSettings = [kVTCompressionPropertyKey_ExpectedFrameRate as String: 15, kVTCompressionPropertyKey_AverageBitRate as String: 600000]
 
         guard let mapViewController = SDLViewControllers.map else {
@@ -147,7 +147,7 @@ class ProxyManager: NSObject {
 // MARK: - SDLStreamingVideoDelegate
 extension ProxyManager: SDLStreamingVideoDelegate {
     func videoStreamingSizeDidUpdate(_ displaySize: CGSize) {
-        print("video stream size updated to width: \(displaySize.width), height: \(displaySize.height)")
+        SDLLog.d("Video stream size updated to width: \(displaySize.width), height: \(displaySize.height)")
     }
 }
 

--- a/MobileNav/SDL/ProxyManager.swift
+++ b/MobileNav/SDL/ProxyManager.swift
@@ -116,7 +116,7 @@ class ProxyManager: NSObject {
 
         streamingMediaConfig.supportedPortraitStreamingRange = SDLVideoStreamingRange(minimumResolution: SDLImageResolution(width: 300, height: 500), maximumResolution: SDLImageResolution(width: UInt16.max, height: UInt16.max))
         streamingMediaConfig.supportedLandscapeStreamingRange = SDLVideoStreamingRange(minimumResolution: SDLImageResolution(width: 500, height: 300), maximumResolution: SDLImageResolution(width: UInt16.max, height: UInt16.max))
-        streamingMediaConfig.delegate = self
+        streamingMediaConfig.delegate = ProxyManager.sharedManager.self
 
         // The video encoder is configured to use the module's preferred framerate and bitrate. If desired, you can provide your custom settings as well. The lowest quality settings between your settings and the module's settings will be used.
         // streamingMediaConfig.customVideoEncoderSettings = [kVTCompressionPropertyKey_ExpectedFrameRate as String: 15, kVTCompressionPropertyKey_AverageBitRate as String: 600000]
@@ -146,7 +146,7 @@ class ProxyManager: NSObject {
 
 // MARK: - SDLStreamingVideoDelegate
 extension ProxyManager: SDLStreamingVideoDelegate {
-    func videoStreamingSizeDidUpdate(_ displaySize: CGSize) {
+    func videoStreamingSizeDidUpdate(toSize displaySize: CGSize) {
         SDLLog.d("Video stream size updated to width: \(displaySize.width), height: \(displaySize.height)")
     }
 }

--- a/MobileNav/SDL/ProxyManager.swift
+++ b/MobileNav/SDL/ProxyManager.swift
@@ -114,9 +114,8 @@ class ProxyManager: NSObject {
         let streamingMediaConfig = SDLStreamingMediaConfiguration()
         streamingMediaConfig.carWindowRenderingType = getSDLRenderType(from: streamSettings.renderType)
 
-        // The app supports all possible screen sizes
-        streamingMediaConfig.supportedPortraitStreamingRange = nil
-        streamingMediaConfig.supportedLandscapeStreamingRange = nil
+        streamingMediaConfig.supportedPortraitStreamingRange = SDLVideoStreamingRange(minimumResolution: SDLImageResolution(width: 300, height: 500), maximumResolution: SDLImageResolution(width: UInt16.max, height: UInt16.max))
+        streamingMediaConfig.supportedLandscapeStreamingRange = SDLVideoStreamingRange(minimumResolution: SDLImageResolution(width: 500, height: 300), maximumResolution: SDLImageResolution(width: UInt16.max, height: UInt16.max))
         streamingMediaConfig.delegate = ProxyManager.sharedManager.self
 
         guard let mapViewController = SDLViewControllers.map else {

--- a/MobileNav/SDL/ProxyManager.swift
+++ b/MobileNav/SDL/ProxyManager.swift
@@ -118,6 +118,9 @@ class ProxyManager: NSObject {
         streamingMediaConfig.supportedLandscapeStreamingRange = SDLVideoStreamingRange(minimumResolution: SDLImageResolution(width: 500, height: 300), maximumResolution: SDLImageResolution(width: UInt16.max, height: UInt16.max))
         streamingMediaConfig.delegate = ProxyManager.sharedManager.self
 
+        // The video encoder is configured to use the module's preferred framerate and bitrate. If desired, you can override the module's preferred settings with custom settings.
+        // streamingMediaConfig.customVideoEncoderSettings = [kVTCompressionPropertyKey_ExpectedFrameRate as String: 15, kVTCompressionPropertyKey_AverageBitRate as String: 600000]
+
         guard let mapViewController = SDLViewControllers.map else {
             SDLLog.e("Error loading the SDL map view")
             return streamingMediaConfig


### PR DESCRIPTION
Added support for the following features:
1. [SDL 0296](https://github.com/smartdevicelink/sdl_ios/issues/1730) - Possibility to update video streaming capabilities during ignition cycle

The SDL_iOS library is now configured to automatically use the module's preferred framerate and bitrate but this can be overridden by the developer if desired. Added instructions for overriding the module's preferred framerate and bitrate. 
1. [SDL 0323](https://github.com/smartdevicelink/sdl_ios/issues/1860) - Align video streaming parameters with VideoStreamingCapability
2. [SDL 0274](https://github.com/smartdevicelink/sdl_ios/issues/1860) - Add preferred FPS to VideoStreamingCapability